### PR TITLE
fix(repo): Update semantic versioning action

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@v4
         with:
           extra_plugins: |
             @semantic-release/git


### PR DESCRIPTION
## What changed?
The GitHub Action managing semantic versioning has been updated from V2 to V4

## Why did it change?

## How did it change?

## Screenshots

## Additional comments