### PR TITLE
Enable Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "16:00"


### PR DESCRIPTION
## What changed?
Every Sunday at 4PM Dependabot will check the npm registry for updates to the dependencies.

## Why did it change?
I want to enable this in order to have up-to-date code.

## How did it change?
Added `dependabot.yml` configuration file.

## Screenshots
N/A

## Additional comments
N/A